### PR TITLE
Nds 48 mapa de sedes

### DIFF
--- a/api/entity/Sedes.js
+++ b/api/entity/Sedes.js
@@ -13,7 +13,13 @@ module.exports = new EntitySchema({
         },
         id_horario:{
             type: "int",
-        }
+        },
+        latitud:{
+            type: "int"
+        },
+        longitud:{
+            type: "int"
+        } 
     },
     relations: {
         categoria: {

--- a/api/entity/Sedes.js
+++ b/api/entity/Sedes.js
@@ -15,10 +15,10 @@ module.exports = new EntitySchema({
             type: "int",
         },
         latitud:{
-            type: "int"
+            type: "decimal"
         },
         longitud:{
-            type: "int"
+            type: "decimal"
         } 
     },
     relations: {

--- a/api/routes/products.js
+++ b/api/routes/products.js
@@ -73,7 +73,13 @@ productsRouter.put('/:id', async (request, response) => {
 productsRouter.delete('/:id', async (request, response) =>  {
     const body = request.body
 
-    await control.borrar(product,{id: request.params.id})
+    const result = await control.borrar(product,{id: request.params.id})
+
+    if (result) {
+        return response.status(204).end()
+    }
+
+    return response.status(404).end()
 })
 
 module.exports = productsRouter

--- a/api/routes/sedes.js
+++ b/api/routes/sedes.js
@@ -103,7 +103,7 @@ sedesRouter.post('/', async (request, response) => {
 
     const newSede =  {
         direccion: body.direccion,
-        latitud: body.latidud,
+        latitud: body.latitud,
         longitud: body.longitud,
         id_horario: savedHorario.identifiers[0].id
     }

--- a/api/routes/sedes.js
+++ b/api/routes/sedes.js
@@ -27,6 +27,8 @@ sedesRouter.get('/', async (request, response) => {
                 const newSede = {
                     id: sedes[x].id,
                     direccion: sedes[x].direccion,
+                    latitud: sedes[x].latitud,
+                    longitud: sedes[x].longitud,
                     id_horario: horario[y].id,
                     hora_apertura: horario[y].hora_apertura,
                     hora_cierre: horario[y].hora_cierre,

--- a/api/routes/sedes.js
+++ b/api/routes/sedes.js
@@ -103,6 +103,8 @@ sedesRouter.post('/', async (request, response) => {
 
     const newSede =  {
         direccion: body.direccion,
+        latitud: body.latidud,
+        longitud: body.longitud,
         id_horario: savedHorario.identifiers[0].id
     }
 
@@ -128,6 +130,8 @@ sedesRouter.put('/update/:id_horario', async (request, response) => {
     const SedeUpdate = {
         id: body.id,
         direccion: body.direccion,
+        latitud: body.latitud,
+        longitud: body.longitud,
         id_horario: body.id_horario
     }
 

--- a/front/.gitignore
+++ b/front/.gitignore
@@ -21,3 +21,4 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.env

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -15018,6 +15018,11 @@
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ=="
     },
+    "use-places-autocomplete": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/use-places-autocomplete/-/use-places-autocomplete-1.9.4.tgz",
+      "integrity": "sha512-iifiwYcjGb0G9HATbwyKpeJgOxWuZwBgPnKGzYgsB2pe5LFGq9udGGFeP0opT/wFk4W/dG8xKTqW0PxLJLc+OQ=="
+    },
     "util": {
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/util/-/util-0.11.1.tgz",

--- a/front/package.json
+++ b/front/package.json
@@ -28,6 +28,7 @@
     "react-material-ui-carousel": "^2.3.1",
     "react-router-dom": "^5.2.0",
     "react-scripts": "4.0.3",
+    "use-places-autocomplete": "^1.9.4",
     "web-vitals": "^1.1.1"
   },
   "peerDependencies": {

--- a/front/src/components/ModalEditSede.js
+++ b/front/src/components/ModalEditSede.js
@@ -44,6 +44,9 @@ const useStyles = makeStyles((theme) => ({
     sede.hora_apertura = props.hora_apertura
     sede.hora_cierre = props.hora_cierre
     sede.descripcion = props.descripcion
+    sede.latitud = props.latitud
+    sede.longitud = props.longitud
+    console.log(props.latitud)
 
     const [state, setState] = useState(sede)
     const [open, setOpen] = useState(false);
@@ -78,9 +81,10 @@ const useStyles = makeStyles((theme) => ({
         Object.keys(state).forEach( async (key) => {
             console.log(state[key])
             console.log(state.direccion)
-            if (key === 'direccion'){
+            console.log(state)
+            if (key === 'direccion' && state[key] !== sede[key]){ //Llamamos a geocode solo si la direccion es diferente
                 console.log("direcciones")
-                toSend[key] = key
+                toSend[key] = state[key]
                 var results = await getGeocode({address: state[key]})
                 var coordinates = (await getLatLng(results[0]))
                 const newCoordinates = {

--- a/front/src/components/ModalEditSede.js
+++ b/front/src/components/ModalEditSede.js
@@ -14,7 +14,12 @@ import DialogContent from '@material-ui/core/DialogContent';
 import DialogContentText from '@material-ui/core/DialogContentText';
 import DialogTitle from '@material-ui/core/DialogTitle';
 import sedeService from '../services/sedes'
+import {useLoadScript} from "@react-google-maps/api"
 
+import usePlacesAutocomplete, {
+  getGeocode,
+  getLatLng,
+} from "use-places-autocomplete";
 
 import Toast from './Toast'
 
@@ -44,6 +49,9 @@ const useStyles = makeStyles((theme) => ({
     const [open, setOpen] = useState(false);
 	const [message, setMessage] = useState(null)
     const [checked, setChecked] = useState(true);
+    const { isLoaded, loadError} = useLoadScript({
+        googleMapsApiKey: 'AIzaSyCpAjZ9gvtVirroeofdUv3ei7lkBTkpEQY'  //Cambiar clave al probar que todo funcione
+    });
 
  	// Actualizar state cada que el prop cambie.
      useEffect(() => setState(sede), [])   
@@ -67,8 +75,23 @@ const useStyles = makeStyles((theme) => ({
         event.stopPropagation();
         event.preventDefault()
 		const toSend = {}
-        Object.keys(state).forEach((key) => {
+        Object.keys(state).forEach( async (key) => {
             console.log(state[key])
+            console.log(state.direccion)
+            if (key === 'direccion'){
+                console.log("direcciones")
+                toSend[key] = key
+                var results = await getGeocode({address: state[key]})
+                var coordinates = (await getLatLng(results[0]))
+                const newCoordinates = {
+                    lat: coordinates.lat,
+                    lng: coordinates.lng
+                }
+                state.latitud = newCoordinates.lat
+                state.longitud = newCoordinates.lng
+                   
+            }
+            
             toSend[key] = state[key]
         })
         

--- a/front/src/components/ModalEditSede.js
+++ b/front/src/components/ModalEditSede.js
@@ -46,7 +46,6 @@ const useStyles = makeStyles((theme) => ({
     sede.descripcion = props.descripcion
     sede.latitud = props.latitud
     sede.longitud = props.longitud
-    console.log(props.latitud)
 
     const [state, setState] = useState(sede)
     const [open, setOpen] = useState(false);
@@ -80,10 +79,7 @@ const useStyles = makeStyles((theme) => ({
 		const toSend = {}
         Object.keys(state).forEach( async (key) => {
             console.log(state[key])
-            console.log(state.direccion)
-            console.log(state)
             if (key === 'direccion' && state[key] !== sede[key]){ //Llamamos a geocode solo si la direccion es diferente
-                console.log("direcciones")
                 toSend[key] = state[key]
                 var results = await getGeocode({address: state[key]})
                 var coordinates = (await getLatLng(results[0]))

--- a/front/src/misc/useSede.js
+++ b/front/src/misc/useSede.js
@@ -1,0 +1,54 @@
+/**
+ * Este archivo implementa el manejo de la sede seleccionada.
+ * Todos los componentes que necesiten acceder esto deben
+ * importar este documento.
+ */
+// https://usehooks.com/useAuth/
+// https://reactrouter.com/web/example/auth-workflow
+
+import React, { useState, useContext, createContext } from "react"
+
+const sedeContext = createContext()
+
+// Componente proveedor del contexto sede a todos los componentes debajo de él (children)
+export function ProvideSede({ children }) {
+    const location = useProvideSede()
+    return <sedeContext.Provider value={location}>{children}</sedeContext.Provider>
+}
+
+// Hook for child components to get the sede object ...
+// ... and re-render when it changes.
+export const useSede = () => {
+    return useContext(sedeContext)
+}
+
+// Provider hook that creates sede object and handles state
+function useProvideSede() {
+    const [sede, setSede] = useState(JSON.parse(window.localStorage.getItem('sede')))
+    const [all, setAll] = useState(JSON.parse(window.localStorage.getItem('all-sedes')) || [])
+    /**
+     * Métodos para manipular el estado de la variable
+     * sede en localStorage.
+     */
+
+    const set = async (obj) => {
+        setSede(obj)
+        window.localStorage.setItem('sede', JSON.stringify(obj))
+    }
+
+    const saveAll = async (foo) => {
+        setAll(foo)
+        window.localStorage.setItem('all-sedes', JSON.stringify(foo))
+    }
+
+    const getInitialState = () => {
+        if(window.localStorage.getItem('all-sedes') === null) {
+            return []
+        }
+        return JSON.parse(window.localStorage.getItem('all-sedes'))
+    }
+
+    return {
+        sede, set, all, saveAll
+    }
+}

--- a/front/src/routes.js
+++ b/front/src/routes.js
@@ -13,7 +13,7 @@ import DashboardPage from "views/Dashboard/Dashboard.js";
 
 import Categorias from "views/Categoria/Categoria.js";
 import Sedes from "views/Sede/Sede.js";
-import Pedidos from "views/Pedidos/Pedidos.js";
+import Pedidos from "views/Sede/sedesMap";
 // Components for users
 import Usuarios from "views/Usuario/Usuario.js";
 import CrearUsuarios from "views/Usuario/CrearUsuario.js";

--- a/front/src/views/Pedidos/Pedidos.js
+++ b/front/src/views/Pedidos/Pedidos.js
@@ -23,7 +23,7 @@ const CustomSkinMap = ({googleMapURL, containerStyle}) => {
 export default function Maps() {
   return (
     <CustomSkinMap
-      googleMapURL="YOUR_KEY_HERE"
+      googleMapURL="AIzaSyCpAjZ9gvtVirroeofdUv3ei7lkBTkpEQY"
       containerStyle={ {height: `100vh` }} 
     />
   );

--- a/front/src/views/Pedidos/Pedidos.js
+++ b/front/src/views/Pedidos/Pedidos.js
@@ -1,5 +1,6 @@
 import React from "react";
 import { GoogleMap, LoadScript } from '@react-google-maps/api'
+import sedesMap from "../Sede/sedesMap"
 
 // Cali
 const center = {
@@ -22,9 +23,6 @@ const CustomSkinMap = ({googleMapURL, containerStyle}) => {
 
 export default function Maps() {
   return (
-    <CustomSkinMap
-      googleMapURL="AIzaSyCpAjZ9gvtVirroeofdUv3ei7lkBTkpEQY"
-      containerStyle={ {height: `100vh` }} 
-    />
+    sedesMap
   );
 }

--- a/front/src/views/Sede/CrearSedes.js
+++ b/front/src/views/Sede/CrearSedes.js
@@ -31,7 +31,9 @@ export default function CreateSede() {
             direccion: state.direccion,
             hora_apertura: state.hora_apertura,
             hora_cierre: state.hora_cierre,
-            descripcion:  state.descripcion
+            descripcion:  state.descripcion,
+            latitud: state.latitud,
+            longitud: state.longitud
         }
 
         try {

--- a/front/src/views/Sede/CrearSedes.js
+++ b/front/src/views/Sede/CrearSedes.js
@@ -6,7 +6,12 @@
 import React from "react";
 // @material-ui/core components
 import SedeService from '../../services/sedes'
+import {useLoadScript} from "@react-google-maps/api"
 
+import usePlacesAutocomplete, {
+  getGeocode,
+  getLatLng,
+} from "use-places-autocomplete";
 import FormNewSede from '../../components/FormNewSede'
 import Toast from '../../components/Toast'
 import FormHandler from '../../variables/formHandler'
@@ -15,6 +20,9 @@ export default function CreateSede() {
   const [state, setState] = React.useState({})
   const [message, setMessage] = React.useState(null)
   
+  const { isLoaded, loadError} = useLoadScript({
+    googleMapsApiKey: 'AIzaSyCpAjZ9gvtVirroeofdUv3ei7lkBTkpEQY'  //Cambiar clave al probar que todo funcione
+});
   const addSede = async (event) =>{
     event.preventDefault()
     // Verificación todo está lleno
@@ -26,14 +34,20 @@ export default function CreateSede() {
         _copyState.errorDireccion = 'Direccion ya existente'
         setState(_copyState)
       } else {
-        // Objeto del nuevo usuario
+        // Objeto de la nueva sede
+        var results = await getGeocode({address: state.direccion})
+        var coordinates = (await getLatLng(results[0]))
+        const newCoordinates = {
+         lat: coordinates.lat,
+         lng: coordinates.lng
+        }
         const newSede = {
             direccion: state.direccion,
             hora_apertura: state.hora_apertura,
             hora_cierre: state.hora_cierre,
             descripcion:  state.descripcion,
-            latitud: state.latitud,
-            longitud: state.longitud
+            latitud: newCoordinates.lat,
+            longitud: newCoordinates.lng
         }
 
         try {

--- a/front/src/views/Sede/sedesMap.js
+++ b/front/src/views/Sede/sedesMap.js
@@ -1,6 +1,10 @@
 import React from "react";
 import {GoogleMap, useLoadScript, Marker, InfoWindow} from "@react-google-maps/api"
-import {formatRelative} from "date-fns"
+import usePlacesAutocomplete, {
+    getGeocode,
+    getLatLng,
+  } from "use-places-autocomplete";
+import sedeService from '../../services/sedes'
 
 const libraries =["places"];
 const mapContainerStyle ={
@@ -17,6 +21,9 @@ const options = {
     zoomControl: true
 }
 
+var sedes = sedeService.getAll().then(function(sites) {sedes = sites})
+
+
 export default function sedesMap () {
     const { isLoaded, loadError} = useLoadScript({
         googleMapsApiKey: "AIzaSyCpAjZ9gvtVirroeofdUv3ei7lkBTkpEQY",
@@ -26,6 +33,20 @@ export default function sedesMap () {
     if (loadError) return "Error cargando el mapa";
     if (!isLoaded) return "Cargando"
 
+    const convertAddress = async (address) => { //convertir la direccion a
+        try {
+            const result = await getGeocode({address});
+            const {lat, lng} = await getLatLng(result[0]);
+            const coordinates = {
+                latitude: lat,
+                longitude: lng
+            }
+            return coordinates
+        } catch (error) {
+            console.log (error)
+        }
+    }
+
     return (
         <GoogleMap
           mapContainerStyle={mapContainerStyle}
@@ -33,6 +54,18 @@ export default function sedesMap () {
           center={center}
           options={options}
 
-        ></GoogleMap>
+        >
+        {Object.values(sedes).map(sede => {
+            const {id, nombre, direccion, id_horario } = sede;
+            <Marker 
+                key={id} 
+                position= {{
+                    lat: 3.435668, 
+                    lng: -76.518606
+                }}
+                />    
+            })}
+
+        </GoogleMap>
     )
 }

--- a/front/src/views/Sede/sedesMap.js
+++ b/front/src/views/Sede/sedesMap.js
@@ -26,8 +26,8 @@ const mapContainerStyle ={
     height: "100vh"
 }
 const center = {
-    lat: 3.420556,
-    lng: -76.52222
+    lat: 3.4461792,
+    lng: -76.5140701
 }
 
 const options = {
@@ -38,6 +38,7 @@ export default function sedesMap () {
 
     const [sedes, setSedes] = useState([]) // Almacena los usuarios traídos de la db.
     const [update, setUpdate] = useState(0) // Para saber si se le ha dado clic a "Actualizar"
+    const [selectedSede, setSelectedSede] = useState(null)
     const previousUpdate = usePrevious(update)
 
     const convertAddress = (address) => { //convertir la direccion a
@@ -56,20 +57,14 @@ export default function sedesMap () {
     useEffect(() => {
         const fetchSedes = async () => {
           const result = await sedeService.getAll()
-          
-          result.forEach( async (item) => {
-              var results = await getGeocode({address: item.direccion})
-              item.coordinates= await getLatLng(results[0]);
-              console.log(item.coordinates)
-              console.log(item)
-          })
-          setSedes(result)
 
           result.forEach((item) => {
             item.id_direccion = item.direccion
             item.id_hora_apertura = item.hora_apertura
             item.id_hora_cierre = item.hora_cierre
             item.id_descripcion = item.descripcion
+            item.id_latitud = item.latitud
+            item.id_longitud = item.longitud
             
           })
           setSedes(result)
@@ -107,22 +102,36 @@ export default function sedesMap () {
           options={options}
 
         >
-         {(sedes).map(sede => {
-            const {id, nombre, direccion, id_horario, coordinates, coordenadas } = sede
-            console.log(sede)
-            console.log(direccion)
-            console.log(sede.coordinates)
-            console.log(coordenadas);
+         {sedes.map(sede => (  //Crear marcadores para el mapa
             <Marker 
-                key={id} 
-                position= {{
-                    lat: 40, 
-                    lng: -3
-                }}
-                />    
-            })}    
-
-
+            key={sede.id} 
+            position= {{
+                lat: parseFloat(sede.latitud), //Se me escapa por qué, pero las coordenadas se convierten en texto en 
+                lng: parseFloat(sede.longitud) //algun lado del traerlas de la BD
+            }}
+            onClick={() => {
+              setSelectedSede(sede);
+            }}
+            /> 
+           
+         ))}    
+         {selectedSede ? (
+           <InfoWindow
+           position = {{
+            lat: parseFloat(selectedSede.latitud), //Se me escapa por qué, pero las coordenadas se convierten en texto en 
+            lng: parseFloat(selectedSede.longitud) //algun lado del traerlas de la BD
+          }}
+          onCloseClick = {() => {
+            setSelectedSede(null);
+          }}
+          
+          >
+             <div>{selectedSede.direccion}
+             <p>{selectedSede.hora_apertura} horas - {selectedSede.hora_cierre} horas</p> 
+             </div>
+              
+           </InfoWindow>
+         ) : null}
         </GoogleMap>
     )
 }

--- a/front/src/views/Sede/sedesMap.js
+++ b/front/src/views/Sede/sedesMap.js
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useRef } from "react";
 import { useLocation } from 'react-router-dom';
+
 import {GoogleMap, useLoadScript, Marker, InfoWindow} from "@react-google-maps/api"
 import usePlacesAutocomplete, {
     getGeocode,

--- a/front/src/views/Sede/sedesMap.js
+++ b/front/src/views/Sede/sedesMap.js
@@ -1,10 +1,23 @@
-import React from "react";
+import React, { useState, useEffect, useRef } from "react";
+import { useLocation } from 'react-router-dom';
 import {GoogleMap, useLoadScript, Marker, InfoWindow} from "@react-google-maps/api"
 import usePlacesAutocomplete, {
     getGeocode,
     getLatLng,
   } from "use-places-autocomplete";
 import sedeService from '../../services/sedes'
+
+function usePrevious(value) {
+    // The ref object is a generic container whose current property is mutable ...
+    // ... and can hold any value, similar to an instance property on a class
+    const ref = useRef();
+    // Store current value in ref
+    useEffect(() => {
+      ref.current = value;
+    }, [value]); // Only re-run if value changes
+    // Return previous value (happens before update in useEffect above)
+    return ref.current;
+  }
 
 const libraries =["places"];
 const mapContainerStyle ={
@@ -20,51 +33,94 @@ const options = {
     //para cuando queramos cambiar como se ve el mapa
     zoomControl: true
 }
-
-var sedes = sedeService.getAll().then(function(sites) {sedes = sites})
-
-
 export default function sedesMap () {
+
+    const [sedes, setSedes] = useState([]) // Almacena los usuarios traídos de la db.
+    const [update, setUpdate] = useState(0) // Para saber si se le ha dado clic a "Actualizar"
+    const previousUpdate = usePrevious(update)
+
+    const convertAddress = (address) => { //convertir la direccion a
+        try {
+            getGeocode({address}).then((results) => getLatLng(results[0]))
+            .then(({ lat, lng }) => {
+               return { lat, lng }      
+            })
+        } catch (error) {
+            console.log (error)
+        }      
+    }
+
+
+
+    useEffect(() => {
+        const fetchSedes = async () => {
+          const result = await sedeService.getAll()
+          
+          result.forEach( async (item) => {
+              var results = await getGeocode({address: item.direccion})
+              item.coordinates= await getLatLng(results[0]);
+              console.log(item.coordinates)
+              console.log(item)
+          })
+          setSedes(result)
+
+          result.forEach((item) => {
+            item.id_direccion = item.direccion
+            item.id_hora_apertura = item.hora_apertura
+            item.id_hora_cierre = item.hora_cierre
+            item.id_descripcion = item.descripcion
+            
+          })
+          setSedes(result)
+          
+        }
+    
+        // Solo llamar a la función si se le ha dado click
+        // al botón de actualizar.
+        if (previousUpdate !== update) {
+          fetchSedes()
+        }
+      }, [update])
+      console.log(sedes)
+     
+      
+  
+
     const { isLoaded, loadError} = useLoadScript({
-        googleMapsApiKey: "AIzaSyCpAjZ9gvtVirroeofdUv3ei7lkBTkpEQY",
+        googleMapsApiKey: 'AIzaSyCpAjZ9gvtVirroeofdUv3ei7lkBTkpEQY',
         libraries,  //Cambiar clave al probar que todo funcione
     });
 
     if (loadError) return "Error cargando el mapa";
     if (!isLoaded) return "Cargando"
 
-    const convertAddress = async (address) => { //convertir la direccion a
-        try {
-            const result = await getGeocode({address});
-            const {lat, lng} = await getLatLng(result[0]);
-            const coordinates = {
-                latitude: lat,
-                longitude: lng
-            }
-            return coordinates
-        } catch (error) {
-            console.log (error)
-        }
-    }
+
+
+
 
     return (
         <GoogleMap
           mapContainerStyle={mapContainerStyle}
-          zoom={7}
+          zoom={16}
           center={center}
           options={options}
 
         >
-        {Object.values(sedes).map(sede => {
-            const {id, nombre, direccion, id_horario } = sede;
+         {(sedes).map(sede => {
+            const {id, nombre, direccion, id_horario, coordinates, coordenadas } = sede
+            console.log(sede)
+            console.log(direccion)
+            console.log(sede.coordinates)
+            console.log(coordenadas);
             <Marker 
                 key={id} 
                 position= {{
-                    lat: 3.435668, 
-                    lng: -76.518606
+                    lat: 40, 
+                    lng: -3
                 }}
                 />    
-            })}
+            })}    
+
 
         </GoogleMap>
     )

--- a/front/src/views/Sede/sedesMap.js
+++ b/front/src/views/Sede/sedesMap.js
@@ -2,10 +2,6 @@ import React, { useState, useEffect, useRef } from "react";
 import { useLocation } from 'react-router-dom';
 
 import {GoogleMap, useLoadScript, Marker, InfoWindow} from "@react-google-maps/api"
-import usePlacesAutocomplete, {
-    getGeocode,
-    getLatLng,
-  } from "use-places-autocomplete";
 import sedeService from '../../services/sedes'
 
 function usePrevious(value) {
@@ -41,16 +37,6 @@ export default function sedesMap () {
     const [selectedSede, setSelectedSede] = useState(null)
     const previousUpdate = usePrevious(update)
 
-    const convertAddress = (address) => { //convertir la direccion a
-        try {
-            getGeocode({address}).then((results) => getLatLng(results[0]))
-            .then(({ lat, lng }) => {
-               return { lat, lng }      
-            })
-        } catch (error) {
-            console.log (error)
-        }      
-    }
 
 
 
@@ -86,31 +72,36 @@ export default function sedesMap () {
         googleMapsApiKey: 'AIzaSyCpAjZ9gvtVirroeofdUv3ei7lkBTkpEQY',
         libraries,  //Cambiar clave al probar que todo funcione
     });
+    
 
     if (loadError) return "Error cargando el mapa";
     if (!isLoaded) return "Cargando"
 
 
 
-
-
     return (
+      <div>
         <GoogleMap
           mapContainerStyle={mapContainerStyle}
-          zoom={16}
+          zoom={14}
           center={center}
           options={options}
+   
 
         >
          {sedes.map(sede => (  //Crear marcadores para el mapa
             <Marker 
             key={sede.id} 
-            position= {{
+            position = {{
                 lat: parseFloat(sede.latitud), //Se me escapa por qué, pero las coordenadas se convierten en texto en 
                 lng: parseFloat(sede.longitud) //algun lado del traerlas de la BD
             }}
-            onClick={() => {
+            onClick = {() => {
               setSelectedSede(sede);
+            }}
+            icon = {{
+              url: "https://i.postimg.cc/yNpPwzwg/pollo-logo-1.png",
+              scaledSize: new window.google.maps.Size(30,30)
             }}
             /> 
            
@@ -133,5 +124,7 @@ export default function sedesMap () {
            </InfoWindow>
          ) : null}
         </GoogleMap>
-    )
+        </div>
+    );
 }
+

--- a/front/src/views/Sede/sedesMap.js
+++ b/front/src/views/Sede/sedesMap.js
@@ -1,0 +1,38 @@
+import React from "react";
+import {GoogleMap, useLoadScript, Marker, InfoWindow} from "@react-google-maps/api"
+import {formatRelative} from "date-fns"
+
+const libraries =["places"];
+const mapContainerStyle ={
+    width: "100vw",
+    height: "100vh"
+}
+const center = {
+    lat: 3.420556,
+    lng: -76.52222
+}
+
+const options = {
+    //para cuando queramos cambiar como se ve el mapa
+    zoomControl: true
+}
+
+export default function sedesMap () {
+    const { isLoaded, loadError} = useLoadScript({
+        googleMapsApiKey: "AIzaSyCpAjZ9gvtVirroeofdUv3ei7lkBTkpEQY",
+        libraries,  //Cambiar clave al probar que todo funcione
+    });
+
+    if (loadError) return "Error cargando el mapa";
+    if (!isLoaded) return "Cargando"
+
+    return (
+        <GoogleMap
+          mapContainerStyle={mapContainerStyle}
+          zoom={7}
+          center={center}
+          options={options}
+
+        ></GoogleMap>
+    )
+}

--- a/front/src/views/Sede/showSedes.js
+++ b/front/src/views/Sede/showSedes.js
@@ -79,7 +79,9 @@ export default function SedesTable(value, onValueChange) {
         id_horario={params.row.id_horario}
         hora_apertura={params.row.hora_apertura}
         hora_cierre={params.row.hora_cierre}
-        descripcion={params.row.descripcion}/>
+        descripcion={params.row.descripcion}
+        latitud={params.row.latitud}
+        longitud={params.row.longitud}/>
         
       )
     },
@@ -95,12 +97,15 @@ export default function SedesTable(value, onValueChange) {
   useEffect(() => {
     const fetchSedes = async () => {
       const result = await sedeService.getAll()
+      console.log(result)
       
       result.forEach((item) => {
         item.id_direccion = item.direccion
         item.id_hora_apertura = item.hora_apertura
         item.id_hora_cierre = item.hora_cierre
         item.id_descripcion = item.descripcion
+        item.id_lat = item.latitud
+        item.id_lng = item.longitud
       })
       setSedes(result)
       
@@ -123,6 +128,7 @@ export default function SedesTable(value, onValueChange) {
     )
     : sedes
 
+    console.log(sedes)
 
   return (
     <React.Fragment>

--- a/front/src/views/Sede/showSedes.js
+++ b/front/src/views/Sede/showSedes.js
@@ -128,7 +128,6 @@ export default function SedesTable(value, onValueChange) {
     )
     : sedes
 
-    console.log(sedes)
 
   return (
     <React.Fragment>


### PR DESCRIPTION
Resumen de los cambios:
-use-places-autocomplete añadido a package.json, para el geocoding.
-La tabla sedes ahora tiene dos columnas extras: latitud y longitud, estas columnas guardan las coordenadas de cada sede.
-Estas columnas no pueden ser nulas, así que habrá que borrar todos los registros de sedes antes de correr la api.
-La creación de sedes ahora llama al geocoder de google para sacar las coordenadas de la dirección dada y enviarlas al api.
-La edición de sedes ahora mira si la dirección cambia para cambiar las coordenadas usando el geocoder y enviar los cambios a la api
-La ruta de pedidos en el dashboard (la que mandaba a la view Pedidos.js que no tenia nada) ahora va a sedesMap.js, donde está el mapa.
-El algoritmo para traer todas las sedes de la base de datos en (routes/sedes) ahora añade los campos latitud y longitud.
-Un cambio pequeño a la ruta de productos para poder mostrar un mensaje al eliminar un producto.

Algunas cosas sobre el mapa: Los marcadores se crean con la latitud y longitud reales de google, lo que quiere decir que se requieren de direcciones reales al crear o editar sedes. Si es posible agregar algo como "cali, colombia" al final para mejorar la precisión (asi fue mi experiencia). En teoria esto soporta sedes en cualquier lugar del mundo. Pero el mapa esta centrado en Cali, y traté de implementar busqueda y centrado basado en la ubicación del navegador pero al final no pude.

Los marcadores al darles click muestran unos pocos detalles (dirección, hora de apertura y cierre). 

Probe editar y crear sedes y no encontré ningún problema (excepto en los casos en que la dirección no fue encontrada) igual les recomiendo que juegen on poquito con eso por si acaso.